### PR TITLE
Base sampling 0 disables adaptive sampling

### DIFF
--- a/benchmark/raytune/run_optimize_configs.py
+++ b/benchmark/raytune/run_optimize_configs.py
@@ -553,10 +553,10 @@ def get_all_sparse_configs(weight_file: str = None, objective: str = "default") 
         )
     ])
     config.masker_configs[2].search_space = {
-        "heavy_size": tune.grid_search([0.01]),
+        "heavy_size": tune.grid_search([0.01, 0.02]),
     }
     config.masker_configs[3].search_space = {
-        "base_rate_sampling": tune.grid_search([0.01, 0.02]),
+        "base_rate_sampling": tune.grid_search([0, 0.01, 0.02]),
         "epsilon": tune.grid_search([0.05]),
         "delta": tune.grid_search([0.05]),
         "init_offset": tune.grid_search([0.01]),

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
@@ -41,7 +41,8 @@ class AdaptiveSamplingMaskerConfig(SamplingMaskerConfig):
 
     Attributes:
         base_rate_sampling: Union[int, float] representing the base sampling rate.
-            If float, must be in (0,1); if int, must be positive.
+            If float, must be in [0,1); if int, must be non-negative.
+            When set to 0, the masker returns the previous mask without modification.
         epsilon: Float in range (0,1) representing the error bound.
         delta: Float in range (0,1) representing the confidence bound.
         init_offset: Union[int, float] representing the start index for sampling.
@@ -68,14 +69,14 @@ class AdaptiveSamplingMaskerConfig(SamplingMaskerConfig):
     def __post_init__(self) -> None:
         """Validate configuration parameters."""
         if isinstance(self.base_rate_sampling, float):
-            if not (0.0 < self.base_rate_sampling < 1.0):
+            if not (0.0 <= self.base_rate_sampling < 1.0):
                 raise ValueError(
-                    f"base_rate_sampling must be in (0, 1) if float, got {self.base_rate_sampling}"
+                    f"base_rate_sampling must be in [0, 1) if float, got {self.base_rate_sampling}"
                 )
         elif isinstance(self.base_rate_sampling, int):
-            if self.base_rate_sampling <= 0:
+            if self.base_rate_sampling < 0:
                 raise ValueError(
-                    f"base_rate_sampling must be positive if int, got {self.base_rate_sampling}"
+                    f"base_rate_sampling must be non-negative if int, got {self.base_rate_sampling}"
                 )
         else:
             raise ValueError(
@@ -141,6 +142,8 @@ class AdaptiveSamplingMasker(SamplingMasker):
         delta_ppf: Pre-computed percentile point function for efficiency.
 
     Important Notes:
+        - If base_rate_sampling is set to 0, the masker returns the previous mask
+          without any modification.
         - The sampling is performed with replacement for efficiency.
         - The masker ignores the previous mask for base sampling to avoid complex
           index manipulation.
@@ -314,6 +317,8 @@ class AdaptiveSamplingMasker(SamplingMasker):
 
         This method implements the core adaptive sampling logic. It combines base
         sampling with adaptive budget allocation based on statistical error bounds.
+        If base_rate_sampling is set to 0, this method returns the previous mask
+        without modification.
 
         Args:
             keys: Key tensor with shape (batch_size, num_heads, seq_len_keys, head_dim).
@@ -332,6 +337,10 @@ class AdaptiveSamplingMasker(SamplingMasker):
             ValueError: If the sampling range is invalid.
         """
         if previous_mask.is_full_mask():
+            return previous_mask
+
+        # If base_rate_sampling is 0, return the previous mask without modification
+        if self.base_rate_sampling == 0:
             return previous_mask
 
         # Extract dimensions and compute attention scores


### PR DESCRIPTION
if base sampling rate is set to 0 then adaptive sampling is skipped. It helps with cases where the best config for vattention requires you to allocate the entire budget to top-k. 