### PR TITLE
fix: add minimal fallback for GPT-OSS prompt formatting

### DIFF
--- a/sparse_attention_hub/adapters/huggingface.py
+++ b/sparse_attention_hub/adapters/huggingface.py
@@ -217,11 +217,17 @@ class ModelAdapterHF(ModelAdapter):
                 tokenize=False,
                 add_generation_prompt=True,
             )
-        new_context = context.split(self.random_separator)[0]
-        new_questions = [
-            question + context.split(self.random_separator)[1] + answer_prefix
-            for question in questions
-        ]
+            new_context = context.split(self.random_separator)[0]
+            new_questions = [
+                question + context.split(self.random_separator)[1] + answer_prefix
+                for question in questions
+            ]
+        else: 
+            new_context = context.split(self.random_separator)[0]
+            new_questions = [
+                f"{context.split(self.random_separator)[0]}\n\nQuestion: {question}\n{answer_prefix}"
+                for question in questions
+            ]
         return new_context, new_questions
 
     def get_custom_attention_function(


### PR DESCRIPTION
# Summary
Fix GPT-OSS compatibility in HuggingFace adapter.

# Change
- Added minimal fallback in `_preprocess_context_and_questions` when `chat_template` is unavailable
- Preserved existing behavior for chat-template models

# Result
- Fixes duplicated/malformed outputs in GPT-style models (Qwen, Falcon)
- No regression for chat-style models

# Tested
- Qwen/Qwen2-0.5B
- tiiuae/falcon-rw-1b
- TinyLlama-1.1B-Chat