### PR TITLE
Fix sparse row-wise mask duplicate handling

### DIFF
--- a/sparse_attention_hub/sparse_attention/utils/mask.py
+++ b/sparse_attention_hub/sparse_attention/utils/mask.py
@@ -460,38 +460,35 @@ class Mask:
             torch.arange(batch_size, device=flat_row_wise_idx.device).unsqueeze(1) * n
         )
 
+        sort_order = torch.argsort(flat_row_wise_idx, dim=1, stable=True)
+        sorted_row_wise_idx = torch.gather(flat_row_wise_idx, dim=1, index=sort_order)
+
+        is_last_duplicate = torch.ones(
+            (batch_size, k), dtype=torch.bool, device=flat_row_wise_idx.device
+        )
+        is_last_duplicate[:, :-1] = (
+            sorted_row_wise_idx[:, :-1] != sorted_row_wise_idx[:, 1:]
+        )
+
         if use_padding:
-            # Slow path: Handle -1 padding (causes GPU-CPU sync via boolean indexing)
-            flat_indices_with_offset: torch.Tensor = flat_row_wise_idx + row_offsets
-
-            # Filter out invalid indices (e.g., -1 padding)
-            valid_mask: torch.Tensor = flat_row_wise_idx >= 0
-            valid_flat_indices: torch.Tensor = flat_indices_with_offset[valid_mask]
-            valid_values: torch.Tensor = flat_data[valid_mask]
-
-            valid_counts_per_row: torch.Tensor = valid_mask.sum(dim=1)
-            ptr: torch.Tensor = torch.cat(
-                [
-                    torch.zeros(1, dtype=torch.long, device=flat_row_wise_idx.device),
-                    torch.cumsum(valid_counts_per_row, dim=0),
-                ]
-            )
+            sorted_valid_mask = sorted_row_wise_idx >= 0
         else:
-            # Fast path: No padding handling (zero-sync, assumes all indices are valid)
-            flat_indices_with_offset = flat_row_wise_idx + row_offsets
+            sorted_valid_mask = torch.ones_like(sorted_row_wise_idx, dtype=torch.bool)
 
-            # Flatten directly without filtering
-            valid_flat_indices = flat_indices_with_offset.reshape(-1)
-            valid_values = flat_data.reshape(-1)
+        sorted_keep_mask = sorted_valid_mask & is_last_duplicate
+        keep_mask = torch.zeros_like(sorted_keep_mask, dtype=torch.bool)
+        keep_mask.scatter_(dim=1, index=sort_order, src=sorted_keep_mask)
+        flat_indices_with_offset = flat_row_wise_idx + row_offsets
+        valid_flat_indices = flat_indices_with_offset[keep_mask]
+        valid_values = flat_data[keep_mask]
 
-            # Create uniform ptr array (each row has exactly k elements)
-            ptr = torch.arange(
-                0,
-                batch_size * k + 1,
-                k,
-                dtype=torch.long,
-                device=flat_row_wise_idx.device,
-            )
+        valid_counts_per_row: torch.Tensor = keep_mask.sum(dim=1)
+        ptr: torch.Tensor = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.long, device=flat_row_wise_idx.device),
+                torch.cumsum(valid_counts_per_row, dim=0),
+            ]
+        )
 
         # Create sparse mask
         sparse_mask: Mask = cls.create_mask_from_indices(

--- a/tests/unit/sparse_attention/research_attention/maskers/fixed/implementations/test_pq_top_k.py
+++ b/tests/unit/sparse_attention/research_attention/maskers/fixed/implementations/test_pq_top_k.py
@@ -1246,7 +1246,7 @@ class TestPQCacheMaskerImplementation:
         )
 
         # Create previous mask (mark some positions as already active)
-        previous_mask: Mask = Mask.create_full_mask(
+        previous_mask: Mask = Mask.create_empty_mask(
             shape=(bsz, n_heads, seq_len_queries, seq_len_keys),
             device=torch.device("cpu"),
             dtype=torch.float32,
@@ -1254,6 +1254,10 @@ class TestPQCacheMaskerImplementation:
         previous_dense: torch.Tensor = previous_mask.get_dense_mask()
         # Mark first 2 positions in quantized region as already active
         previous_dense[:, :, :, config.init_offset : config.init_offset + 2] = 1.0
+        assert (
+            (previous_dense != 0).sum().item()
+            == bsz * n_heads * seq_len_queries * 2
+        )
         previous_mask = Mask(
             shape=previous_dense.shape,
             mask=previous_dense,

--- a/tests/unit/sparse_attention/utils/test_mask.py
+++ b/tests/unit/sparse_attention/utils/test_mask.py
@@ -251,6 +251,27 @@ class TestMask:
         assert torch.allclose(ptr, expected_ptr)
         assert torch.allclose(values, expected_values)
 
+    def test_create_from_row_wise_idx_sparse_index_preserves_unique_input_order(self):
+        """Sparse index mode should preserve row-wise order when indices are unique."""
+        shape = (2, 6)
+        row_wise_idx = torch.tensor([[3, 1, 4], [2, 0, 5]])
+        data = torch.tensor([[0.3, 0.1, 0.4], [1.2, 1.0, 1.5]])
+
+        mask = Mask.create_from_row_wise_idx(
+            shape,
+            row_wise_idx,
+            data,
+            mask_type="index",
+            dtype=torch.float32,
+            mode="sparse",
+        )
+
+        indices, ptr, values = mask.get_index_mask()
+
+        torch.testing.assert_close(indices, torch.tensor([3, 1, 4, 8, 6, 11]))
+        torch.testing.assert_close(ptr, torch.tensor([0, 3, 6]))
+        torch.testing.assert_close(values, data.reshape(-1))
+
     def test_create_from_row_wise_idx_single_element(self):
         """Test with single element per row."""
         shape = (3, 4)
@@ -286,6 +307,30 @@ class TestMask:
         dense_mask = mask.get_dense_mask()
         expected = torch.tensor([[1.0, 0.0, 0.5, 0.0, 0.0], [0.0, 0.6, 0.0, 0.0, 0.0]])
         assert torch.allclose(dense_mask, expected)
+
+    def test_create_from_row_wise_idx_sparse_padding_preserves_valid_input_order(self):
+        """Padding mode should filter -1 values without reordering valid entries."""
+        shape = (2, 6)
+        row_wise_idx = torch.tensor([[3, -1, 1, 4], [2, 0, -1, 5]])
+        data = torch.tensor([[0.3, 0.0, 0.1, 0.4], [1.2, 1.0, 0.0, 1.5]])
+
+        mask = Mask.create_from_row_wise_idx(
+            shape,
+            row_wise_idx,
+            data,
+            mask_type="index",
+            dtype=torch.float32,
+            use_padding=True,
+            mode="sparse",
+        )
+
+        indices, ptr, values = mask.get_index_mask()
+
+        torch.testing.assert_close(indices, torch.tensor([3, 1, 4, 8, 6, 11]))
+        torch.testing.assert_close(ptr, torch.tensor([0, 3, 6]))
+        torch.testing.assert_close(
+            values, torch.tensor([0.3, 0.1, 0.4, 1.2, 1.0, 1.5])
+        )
 
     def test_create_from_row_wise_idx_multidimensional(self):
         """Test with multi-dimensional batch shape."""
@@ -1440,3 +1485,28 @@ class TestMask:
 
         print("\n✅ All edge case tests passed!")
         print("=" * 80 + "\n")
+
+    def test_create_from_row_wise_idx_sparse_index_duplicates_keep_last_value(self):
+        """Sparse index mode should match dense scatter_ behavior for duplicates."""
+        shape = (2, 5)
+        row_wise_idx = torch.tensor([[1, 3, 1, 1], [2, 2, 4, 2]])
+        data = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+
+        mask = Mask.create_from_row_wise_idx(
+            shape,
+            row_wise_idx,
+            data,
+            mask_type="index",
+            dtype=torch.float32,
+            mode="sparse",
+        )
+
+        expected = torch.zeros(shape, dtype=torch.float32)
+        expected.scatter_(dim=-1, index=row_wise_idx, src=data)
+
+        indices, ptr, index_data = mask.get_index_mask()
+
+        torch.testing.assert_close(indices, torch.tensor([3, 1, 9, 7]))
+        torch.testing.assert_close(ptr, torch.tensor([0, 2, 4]))
+        torch.testing.assert_close(mask.get_dense_mask(), expected)
+        torch.testing.assert_close(index_data, torch.tensor([2.0, 4.0, 7.0, 8.0]))


### PR DESCRIPTION
## Summary
- fix sparse row-wise mask creation so duplicate indices keep the last occurrence, matching dense scatter semantics
- preserve existing sparse index ordering for unique no-padding inputs and padding-filtered inputs
- fix the PQ mask unit fixture so it starts from an empty previous mask before marking two positions active

## Tests
- /Users/kumarkagrawal/local/berkeley/skylight/sparse-attention-hub-row-wise-mask-fix/.venv/bin/pytest -m unit --tb=short -q
- Result: 767 passed, 6 skipped, 135 deselected